### PR TITLE
fix: add colorette dependency to ts example

### DIFF
--- a/examples/with-typescript-recommended/package.json
+++ b/examples/with-typescript-recommended/package.json
@@ -18,6 +18,7 @@
 		"@sapphire/time-utilities": "^1.5.2",
 		"@sapphire/type": "^2.1.2",
 		"@sapphire/utilities": "^3.2.1",
+		"colorette": "^2.0.16",
 		"discord.js": "^13.6.0",
 		"dotenv-cra": "^3.0.2",
 		"reflect-metadata": "^0.1.13"


### PR DESCRIPTION
colorette is used in [src/listeners/ready.ts](https://github.com/sapphiredev/examples/blob/main/examples/with-typescript-recommended/src/listeners/ready.ts#L3) but is missing in the package.json. This PR fixes that error.