### PR TITLE
fix(with-docker): added missing dotenv-cra dev-dependency

### DIFF
--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -26,7 +26,8 @@
 		"@sapphire/time-utilities": "^1.7.5",
 		"@sapphire/type": "^2.2.4",
 		"@sapphire/utilities": "^3.9.1",
-		"discord.js": "^13.10.2"
+		"discord.js": "^13.10.2",
+		"dotenv-cra": "^3.0.2"
 	},
 	"devDependencies": {
 		"@sapphire/prettier-config": "^1.4.3",

--- a/examples/with-docker/src/lib/constants.ts
+++ b/examples/with-docker/src/lib/constants.ts
@@ -1,0 +1,6 @@
+import { join } from 'path';
+
+export const rootDir = join(__dirname, '..', '..');
+export const srcDir = join(rootDir, 'src');
+
+export const RandomLoadingMessage = ['Computing...', 'Thinking...', 'Cooking some food', 'Give me a moment', 'Loading...'];

--- a/examples/with-docker/src/lib/constants.ts
+++ b/examples/with-docker/src/lib/constants.ts
@@ -2,5 +2,3 @@ import { join } from 'path';
 
 export const rootDir = join(__dirname, '..', '..');
 export const srcDir = join(rootDir, 'src');
-
-export const RandomLoadingMessage = ['Computing...', 'Thinking...', 'Cooking some food', 'Give me a moment', 'Loading...'];

--- a/examples/with-docker/src/lib/setup.ts
+++ b/examples/with-docker/src/lib/setup.ts
@@ -1,8 +1,17 @@
+// Unless explicitly defined, set NODE_ENV as development:
+process.env.NODE_ENV ??= 'development';
+
 import '@sapphire/plugin-api/register';
 import '@sapphire/plugin-editable-commands/register';
 import '@sapphire/plugin-logger/register';
 import * as colorette from 'colorette';
+import { config } from 'dotenv-cra';
+import { join } from 'path';
 import { inspect } from 'util';
+import { srcDir } from './constants';
+
+// Read env var
+config({ path: join(srcDir, '.env') });
 
 // Set default inspection depth
 inspect.defaultOptions.depth = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,6 +5300,7 @@ __metadata:
     "@types/node": ^18.7.8
     "@types/ws": ^8.5.3
     discord.js: ^13.10.2
+    dotenv-cra: ^3.0.2
     npm-run-all: ^4.1.5
     prettier: ^2.7.1
     tsc-watch: ^5.0.3


### PR DESCRIPTION
Fixing missing dotenv-cra requirements while generating a new project from scratch using the template with Docker support.