### PR TITLE
fix: rootdir in constants.ts

### DIFF
--- a/examples/with-swc/src/lib/constants.ts
+++ b/examples/with-swc/src/lib/constants.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-export const rootDir = join(__dirname, '..', '..');
+export const rootDir = join(__dirname, '..', '..', '..');
 export const srcDir = join(rootDir, 'src');
 
 export const RandomLoadingMessage = ['Computing...', 'Thinking...', 'Cooking some food', 'Give me a moment', 'Loading...'];


### PR DESCRIPTION
This template ends up outputting code to `dist/src/` which causes the rootdir to end up being "dist/", causing stuff to be incorrect.  This was found out over in this thread: https://discord.com/channels/737141877803057244/1213284909976780822

I tried playing around with swc and tsconfigs to get swc to output directly to `dist/` but i couldnt make it work, so this was the easiest way to fix it