### PR TITLE
ci: setup reusable workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,35 +8,7 @@ on:
 
 jobs:
   formatting:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v4
-      - name: Use Node.js v20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-          registry-url: https://registry.npmjs.org/
-      - name: Install Dependencies
-        run: yarn install --immutable
-      - name: Run Prettier
-        run: yarn format:check
+    uses: sapphiredev/.github/.github/workflows/reusable-prettier-check.yml@main
 
   linting:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v4
-      - name: Use Node.js v20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-          registry-url: https://registry.npmjs.org/
-      - name: Install Dependencies
-        run: yarn install --immutable
-      - name: Run ESLint
-        run: yarn lint --fix=false
+    uses: sapphiredev/.github/.github/workflows/reusable-linting.yml@main

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   formatting:
+    name: Formatting
     uses: sapphiredev/.github/.github/workflows/reusable-prettier-check.yml@main
 
   linting:
+    name: Linting
     uses: sapphiredev/.github/.github/workflows/reusable-linting.yml@main

--- a/.github/workflows/labelsync.yml
+++ b/.github/workflows/labelsync.yml
@@ -7,17 +7,4 @@ on:
 
 jobs:
   label_sync:
-    name: Automatic Label Synchronization
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/labels.yml
-          sparse-checkout-cone-mode: false
-          repository: 'sapphiredev/.github'
-      - name: Run Label Sync
-        uses: crazy-max/ghaction-github-labeler@v5
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          yaml-file: .github/labels.yml
+    uses: sapphiredev/.github/.github/workflows/reusable-labelsync.yml@main


### PR DESCRIPTION
This cleans up the workflows a lot. If this works and is approved I will continue to set it up in all the other sapphire repos

Also refer to the files here: https://github.com/sapphiredev/.github/tree/main/.github/workflows