### PR TITLE
Update mentionPrefixOnly.ts

### DIFF
--- a/examples/with-typescript-complete/src/listeners/mentionPrefixOnly.ts
+++ b/examples/with-typescript-complete/src/listeners/mentionPrefixOnly.ts
@@ -1,10 +1,10 @@
 import type { Events } from '@sapphire/framework';
 import { Listener } from '@sapphire/framework';
-import type { Message } from 'discord.js';
+import { TextChannel, type Message } from 'discord.js';
 
 export class UserEvent extends Listener<typeof Events.MentionPrefixOnly> {
 	public override async run(message: Message) {
 		const prefix = this.container.client.options.defaultPrefix;
-		return message.channel.send(prefix ? `My prefix in this guild is: \`${prefix}\`` : 'Cannot find any Prefix for Message Commands.');
+		return (message.channel as TextChannel).send(prefix ? `My prefix in this guild is: \`${prefix}\`` : 'Cannot find any Prefix for Message Commands.');
 	}
 }


### PR DESCRIPTION
Fix `Property 'send' does not exist on type 'PartialGroupDMChannel'`, by casting as TextChannel.